### PR TITLE
Fix `SpectrographObservation.empty()` ignoring custom axis names

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,6 +32,8 @@ jobs:
           pip install setuptools wheel
           pip install -e .[test]
       - name: Test with pytest
+        env:
+          MPLBACKEND: "agg"
         run: |
           pip install pytest pytest-cov
           pytest --cov=. --cov-report=xml

--- a/iris/sg/_spectrograph.py
+++ b/iris/sg/_spectrograph.py
@@ -369,11 +369,11 @@ class SpectrographObservation(
                 ),
             ),
             crpix=na.CartesianNdVectorArray(
-                components=dict(
-                    wavelength=na.ScalarArray.zeros(shape_base),
-                    detector_x=na.ScalarArray.zeros(shape_base),
-                    detector_y=na.ScalarArray.zeros(shape_base),
-                )
+                components={
+                    axis_wavelength: na.ScalarArray.zeros(shape_base),
+                    axis_detector_x: na.ScalarArray.zeros(shape_base),
+                    axis_detector_y: na.ScalarArray.zeros(shape_base),
+                }
             ),
             cdelt=na.SpectralPositionalVectorArray(
                 wavelength=na.ScalarArray.zeros(shape_base) << u.AA,
@@ -384,26 +384,26 @@ class SpectrographObservation(
             ),
             pc=na.SpectralPositionalMatrixArray(
                 wavelength=na.CartesianNdVectorArray(
-                    components=dict(
-                        wavelength=na.ScalarArray.zeros(shape_base),
-                        detector_x=na.ScalarArray.zeros(shape_base),
-                        detector_y=na.ScalarArray.zeros(shape_base),
-                    ),
+                    components={
+                        axis_wavelength: na.ScalarArray.zeros(shape_base),
+                        axis_detector_x: na.ScalarArray.zeros(shape_base),
+                        axis_detector_y: na.ScalarArray.zeros(shape_base),
+                    },
                 ),
                 position=na.Cartesian2dMatrixArray(
                     x=na.CartesianNdVectorArray(
-                        components=dict(
-                            wavelength=na.ScalarArray.zeros(shape_base),
-                            detector_x=na.ScalarArray.zeros(shape_base),
-                            detector_y=na.ScalarArray.zeros(shape_base),
-                        ),
+                        components={
+                            axis_wavelength: na.ScalarArray.zeros(shape_base),
+                            axis_detector_x: na.ScalarArray.zeros(shape_base),
+                            axis_detector_y: na.ScalarArray.zeros(shape_base),
+                        },
                     ),
                     y=na.CartesianNdVectorArray(
-                        components=dict(
-                            wavelength=na.ScalarArray.zeros(shape_base),
-                            detector_x=na.ScalarArray.zeros(shape_base),
-                            detector_y=na.ScalarArray.zeros(shape_base),
-                        ),
+                        components={
+                            axis_wavelength: na.ScalarArray.zeros(shape_base),
+                            axis_detector_x: na.ScalarArray.zeros(shape_base),
+                            axis_detector_y: na.ScalarArray.zeros(shape_base),
+                        },
                     ),
                 ),
             ),

--- a/iris/sg/_spectrograph_test.py
+++ b/iris/sg/_spectrograph_test.py
@@ -48,3 +48,28 @@ class TestSpectrographObservation:
     def test_to_jshtml(self, array: iris.sg.SpectrographObservation):
         result = array.to_jshtml()
         assert isinstance(result, IPython.display.HTML)
+
+
+def test_empty_custom_axes():
+
+    axis_wavelength = "velocity"
+    axis_detector_x = "x"
+    axis_detector_y = "y"
+
+    result = iris.sg.SpectrographObservation.empty(
+        shape_base=dict(time=1),
+        shape_wcs={
+            axis_wavelength: 2,
+            axis_detector_x: 3,
+            axis_detector_y: 4,
+        },
+        axis_wavelength=axis_wavelength,
+        axis_detector_x=axis_detector_x,
+        axis_detector_y=axis_detector_y,
+    )
+
+    axes = {axis_wavelength, axis_detector_x, axis_detector_y}
+    assert set(result.inputs.crpix.components) == axes
+    assert set(result.inputs.pc.wavelength.components) == axes
+    assert set(result.inputs.pc.position.x.components) == axes
+    assert set(result.inputs.pc.position.y.components) == axes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "requests",
     "joblib",
     "irispy-lmsal",
-    "named-arrays~=1.3",
+    "named-arrays~=2.0",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
## Summary

`SpectrographObservation.empty()` constructed the `crpix` and `pc` WCS components with hardcoded `wavelength`/`detector_x`/`detector_y` keys, ignoring the `axis_wavelength`, `axis_detector_x`, and `axis_detector_y` parameters. Since `open()` accesses those components using the caller's axis names (`crpix.components[axis_wavelength]` etc.), any call with non-default axis names crashed with a `KeyError`.

Found while building `esis.data.synth.scene_iris()`, which calls `iris.sg.open(axis_wavelength="velocity", ...)`.

## Changes

- Build the `crpix` and `pc` component dicts in `empty()` from the axis-name parameters instead of hardcoded keys.
- Add a no-network regression test, `test_empty_custom_axes`, asserting the component keys match the requested axis names.
- Bump the `named-arrays` requirement from `~=1.3` to `~=2.0`: the code already relies on 2.0 features (e.g. `na.ExplicitTemporalWcsDopplerPositionalVectorArray`), and the old pin makes this package uninstallable alongside packages that require `named-arrays~=2.0` (such as `esis`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xbhx4BAV3jBQBkdCKnfRVK